### PR TITLE
Add Base32-encoded CID length validation

### DIFF
--- a/app/src/apdu_handler.c
+++ b/app/src/apdu_handler.c
@@ -46,6 +46,10 @@ void extractHDPath(uint32_t rx, uint32_t offset, uint32_t path_len) {
         THROW(APDU_CODE_DATA_INVALID);
     }
 
+    if (rx < offset) {
+        THROW(APDU_CODE_WRONG_LENGTH);
+    }
+
     if ((rx - offset) < sizeof(uint32_t) * path_len) {
         THROW(APDU_CODE_WRONG_LENGTH);
     }

--- a/app/src/fil_utils.c
+++ b/app/src/fil_utils.c
@@ -287,7 +287,6 @@ parser_error_t parse_cid(cid_t *cid, CborValue *value) {
     return parser_invalid_cid;
 }
 
-// return lenght
 parser_error_t printCid(cid_t *cid, char *outVal, uint16_t outValLen, uint8_t pageIdx, uint8_t *pageCount) {
     // 100-bytes is good enough
     char outBuffer[100] = {0};
@@ -297,7 +296,11 @@ parser_error_t printCid(cid_t *cid, char *outVal, uint16_t outValLen, uint8_t pa
     // filecoin uses base32 which base prefix is b.
     *outBuffer = 'b';
 
-    if (cid->len > (MAX_CID_LEN + 1)) {
+    // Ensure base32-encoded output fits into outBuffer:
+    // encoded_len = ceil(8 * cid->len / 5)
+    // need 1 byte for 'b' prefix and 1 for terminating NUL
+    size_t enc_len = (8 * cid->len + 4) / 5;
+    if (enc_len > (sizeof(outBuffer) - 2)) {
         return parser_no_data;
     }
 


### PR DESCRIPTION
<!-- ClickUpRef: 869a4wx82 -->
:link: [zboto Link](https://app.clickup.com/t/869a4wx82)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Improved input validation for paths and quantities to prevent overflows and invalid operations.
  - Safer address/public key handling and signing safeguards.
  - Pre-encode size checks to avoid buffer overruns.
  - More consistent error messaging (“Data is invalid”).
- Tests
  - Updated expectations to new error messages and added transport reset in flow.
  - Removed an unstable BLS negative test.
- Chores
  - Bumped app patch version.
  - Updated dependencies and external library reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->